### PR TITLE
fix: correct version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@salutejs/perftool",
-    "version": "0.3.0",
+    "version": "0.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salutejs/perftool",
-    "version": "0.3.0",
+    "version": "0.3.2",
     "author": "Salute Frontend Team <salute.developers@gmail.com>",
     "description": "Performance measurement tool for frontend components",
     "repository": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.3--canary.1.4076026557.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.3.3--canary.1.4076026557.0
  # or 
  yarn add @salutejs/perftool@0.3.3--canary.1.4076026557.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
