### PR TITLE
fix: correct token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -69,7 +68,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions-js/push@master
         with:
-          github_token: ${{ secrets.secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           message: 'chore: update package-locks [skip ci]'
           branch: ${{ steps.extract_branch.outputs.branch }}
           author_name: Salute Frontend Team

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@salutejs/perftool",
-    "version": "0.3.2",
+    "version": "0.3.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salutejs/perftool",
-    "version": "0.3.2",
+    "version": "0.3.5",
     "author": "Salute Frontend Team <salute.developers@gmail.com>",
     "description": "Performance measurement tool for frontend components",
     "repository": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.6--canary.2.4076229275.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.3.6--canary.2.4076229275.0
  # or 
  yarn add @salutejs/perftool@0.3.6--canary.2.4076229275.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
