### PR TITLE
Fix: running as root without --no-sandbox is not supported

### DIFF
--- a/packages/perftool/lib/controller/__spec__/__snapshots__/executor.test.ts.snap
+++ b/packages/perftool/lib/controller/__spec__/__snapshots__/executor.test.ts.snap
@@ -5,6 +5,7 @@ exports[`controller/Executor should create Executor instance with factory 1`] = 
   {
     "args": [
       "--js-flags="--maglev=false --max_opt=0"",
+      "--no-sandbox",
     ],
     "devtools": true,
     "headless": true,

--- a/packages/perftool/lib/controller/executor.ts
+++ b/packages/perftool/lib/controller/executor.ts
@@ -55,7 +55,7 @@ export default class Executor<T extends Task<any, any, any>[]> implements IExecu
 
         const browserInstance = await puppeteer.launch({
             headless: true,
-            args: ['--js-flags="--maglev=false --max_opt=0"'],
+            args: ['--js-flags="--maglev=false --max_opt=0"', '--no-sandbox'],
             ...config.puppeteerOptions,
         });
         debug('[executor]', 'launched browser successfully');


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.7.1-canary.14.4901897727.0
  # or 
  yarn add @salutejs/perftool@0.7.1-canary.14.4901897727.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
