### PR TITLE
Fix dependency on CWD's (external) typescript

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,3 +104,34 @@ jobs:
         run: |
           cd spec/main-suite
           pnpm run integration:unchanged
+
+  bad_typescript:
+    name: Project with different typescript version
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Setup packages
+        run: pnpm install
+
+      - name: Prepare
+        run: |
+          cd spec/main-suite
+          pnpm run integration:prepare
+
+      - name: Install bad ts-node version
+        run: |
+          cd spec/main-suite
+          pnpm add typescript@4.0.8
+
+      - name: Run perftool
+        run: |
+          cd spec/main-suite
+          pnpm run integration:unchanged

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "8.38.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.8.0",
+    "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jest": "27.2.1",
     "eslint-plugin-prettier": "4.2.1",

--- a/packages/perftool/lib/build/collect.ts
+++ b/packages/perftool/lib/build/collect.ts
@@ -1,10 +1,12 @@
 import { readFile } from 'fs/promises';
 import fg from 'fast-glob';
+import path from 'path';
 
 import getSubjectId from '../utils/subjectId';
 import checkPath from '../utils/checkPath';
 import { Config } from '../config';
 import { debug, info, warn } from '../utils/logger';
+import CWD from '../utils/cwd';
 
 export type ExportPickRule = 'named'; // | 'default' | 'all'
 
@@ -32,34 +34,35 @@ function getExports(fileContents: string, exportPickRule: ExportPickRule): strin
     return method(fileContents);
 }
 
-async function getTestModule(path: string, exportPickRule: ExportPickRule): Promise<TestModule | null> {
-    debug('getting test subjects from module ', path);
+async function getTestModule(modulePath: string, exportPickRule: ExportPickRule): Promise<TestModule | null> {
+    const moduleAbsolutePath = path.resolve(CWD, modulePath);
+    debug('getting test subjects from module ', modulePath);
     debug('export pick rule is ', exportPickRule);
 
-    const isModuleAvailable = await checkPath(path);
+    const isModuleAvailable = await checkPath(moduleAbsolutePath);
 
     if (!isModuleAvailable) {
-        warn('module ', path, ' is not available, skipping');
+        warn('module ', moduleAbsolutePath, ' is not available, skipping');
         return null;
     }
 
-    const contents = await readFile(path, { encoding: 'utf8' });
+    const contents = await readFile(moduleAbsolutePath, { encoding: 'utf8' });
     const exports = getExports(contents, exportPickRule);
 
     if (!exports.length) {
-        warn('module ', path, 'has no suitable exports, skipping');
+        warn('module ', moduleAbsolutePath, 'has no suitable exports, skipping');
         return null;
     }
 
     debug('found exports ', exports);
 
     const subjects = exports.map((originalExportedName) => ({
-        id: getSubjectId(path, originalExportedName),
+        id: getSubjectId(modulePath, originalExportedName),
         originalExportedName,
     }));
 
     return {
-        path,
+        path: modulePath,
         subjects,
     };
 }
@@ -68,7 +71,7 @@ export default async function collectTestSubjects(config: Config): Promise<TestM
     info('Collecting test subjects...');
     debug('include: ', config.include, 'exclude: ', config.exclude);
 
-    const paths = await fg(config.include, { ignore: config.exclude });
+    const paths = await fg(config.include, { ignore: config.exclude, cwd: CWD });
 
     debug('found modules: ', paths);
     debug('parsing modules... ');

--- a/packages/perftool/lib/build/entrypoint.ts
+++ b/packages/perftool/lib/build/entrypoint.ts
@@ -5,12 +5,13 @@ import path from 'path';
 import { formatImportExpression, formatLines } from '../utils/codegen';
 import { Config } from '../config';
 import { debug } from '../utils/logger';
+import CWD from '../utils/cwd';
 
 import { TestModule } from './collect';
 
 function getModuleRelativePath(modulePath: string, importedModulePath: string): string {
-    const moduleDir = path.join(modulePath, '..');
-    const relativePath = path.relative(moduleDir, importedModulePath);
+    const moduleDir = path.dirname(modulePath);
+    const relativePath = path.relative(moduleDir, path.resolve(CWD, importedModulePath));
 
     return relativePath.replace(path.extname(importedModulePath), '');
 }

--- a/packages/perftool/lib/compare/index.ts
+++ b/packages/perftool/lib/compare/index.ts
@@ -6,6 +6,7 @@ import { createCommand, createArgument, createOption } from 'commander';
 import { getConfig } from '../config';
 import { debug, error, info, setLogLevel } from '../utils/logger';
 import { importConfig } from '../config/node';
+import CWD from '../utils/cwd';
 
 import { processReports } from './process';
 
@@ -31,12 +32,12 @@ async function start() {
     const config = getConfig(options, importedConfig?.value);
 
     info('Comparing runs...');
-    const outputPath = path.resolve(cli.opts().outputFilePath || './perftest/comparison.json');
+    const outputPath = path.resolve(CWD, cli.opts().outputFilePath || './perftest/comparison.json');
     const [current, previous] = cli.processedArgs;
 
     const [currentReport, previousReport] = await Promise.all([
-        fsPromises.readFile(path.resolve(current), { encoding: 'utf-8' }).then(JSON.parse),
-        fsPromises.readFile(path.resolve(previous), { encoding: 'utf-8' }).then(JSON.parse),
+        fsPromises.readFile(path.resolve(CWD, current), { encoding: 'utf-8' }).then(JSON.parse),
+        fsPromises.readFile(path.resolve(CWD, previous), { encoding: 'utf-8' }).then(JSON.parse),
     ]);
 
     const result = await processReports(config, currentReport, previousReport);

--- a/packages/perftool/lib/config/index.ts
+++ b/packages/perftool/lib/config/index.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 
+import CWD from '../utils/cwd';
+
 export { getConfig } from './common';
 export type { Config, ProjectConfig } from './common';
 
@@ -7,7 +9,7 @@ export { getTaskConfig, getAllTasks } from './task';
 
 export { getWebpackConfig } from './webpack';
 
-export const distDirectory = path.resolve('./perftoolTmpDist');
+export const distDirectory = path.resolve(CWD, './perftoolTmpDist');
 
 export const buildDirectory = path.resolve(distDirectory, 'build');
 

--- a/packages/perftool/lib/config/node.ts
+++ b/packages/perftool/lib/config/node.ts
@@ -2,11 +2,12 @@ import path from 'path';
 
 import checkPath from '../utils/checkPath';
 import { debug, error, info } from '../utils/logger';
+import CWD from '../utils/cwd';
 
 import { ProjectConfig } from './common';
 
-const defaultJsConfigPath = path.resolve('./perftool.config.mjs');
-const defaultTsConfigPath = path.resolve('./perftool.config.mts');
+const defaultJsConfigPath = path.resolve(CWD, './perftool.config.mjs');
+const defaultTsConfigPath = path.resolve(CWD, './perftool.config.mts');
 
 type ImportedConfig = {
     path: string;
@@ -15,7 +16,7 @@ type ImportedConfig = {
 
 export async function importConfig(cliConfigPath?: string): Promise<ImportedConfig | null> {
     debug('importing project config');
-    let configPath = cliConfigPath ? path.resolve(cliConfigPath) : undefined;
+    let configPath = cliConfigPath ? path.resolve(CWD, cliConfigPath) : undefined;
     debug('cli config path is ', configPath);
 
     if (configPath && !(await checkPath(configPath))) {

--- a/packages/perftool/lib/config/webpack.ts
+++ b/packages/perftool/lib/config/webpack.ts
@@ -5,15 +5,17 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { debug } from '../utils/logger';
+import CWD from '../utils/cwd';
 
 import { Config } from './common';
 
 const require = createRequire(import.meta.url);
 const dirname = path.dirname(fileURLToPath(import.meta.url));
-const ownNodeModules = path.relative(process.cwd(), path.resolve(dirname, '../../node_modules'));
+const ownNodeModules = path.relative(CWD, path.resolve(dirname, '../../node_modules'));
 
 const defaultConfig: WebpackConfig = {
     mode: 'production',
+    context: CWD,
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs'],
         modules: ['node_modules', ownNodeModules],

--- a/packages/perftool/lib/reporter/index.ts
+++ b/packages/perftool/lib/reporter/index.ts
@@ -1,6 +1,5 @@
 import * as os from 'os';
 import path from 'path';
-import process from 'process';
 import fsPromises from 'fs/promises';
 
 import { StatsReport } from '../statistics';
@@ -9,6 +8,7 @@ import { TestModule } from '../build/collect';
 import { Config } from '../config';
 import getCurrentVersion from '../utils/version';
 import { id as staticTaskSubjectId } from '../stabilizers/staticTask';
+import CWD from '../utils/cwd';
 
 export type ReportWithMeta = {
     version: string;
@@ -35,10 +35,9 @@ export async function report(statsStream: AsyncGenerator<StatsReport, undefined>
 }
 
 function getSubjectIdToReadableNameMap(testModules: TestModule[]) {
-    const cwd = process.cwd();
     return testModules.reduce((acc, { subjects, path: modulePath }) => {
         subjects.forEach(({ id, originalExportedName }) => {
-            acc[id] = `${path.relative(cwd, path.resolve(modulePath))}#${originalExportedName}`;
+            acc[id] = `${path.relative(CWD, path.resolve(CWD, modulePath))}#${originalExportedName}`;
         });
 
         return acc;
@@ -69,7 +68,7 @@ export async function generateReport(config: Config, data: StatsReport, testModu
     }
 
     const contents = JSON.stringify(reportWithMeta, null, 2);
-    const fileName = path.resolve(config.outputFilePath.replace('[time]', new Date().toISOString()));
+    const fileName = path.resolve(CWD, config.outputFilePath.replace('[time]', new Date().toISOString()));
 
     await fsPromises.mkdir(path.dirname(fileName), { recursive: true });
     await fsPromises.writeFile(fileName, contents, { encoding: 'utf-8' });

--- a/packages/perftool/lib/utils/cwd.ts
+++ b/packages/perftool/lib/utils/cwd.ts
@@ -1,0 +1,5 @@
+import process from 'process';
+
+const CWD = String(process.env.PERFTOOL_CWD);
+
+export default CWD;

--- a/packages/perftool/lib/utils/subjectId.ts
+++ b/packages/perftool/lib/utils/subjectId.ts
@@ -1,11 +1,9 @@
 import path from 'path';
-import process from 'process';
 
 import getHashCode from './hash';
+import CWD from './cwd';
 
 // kinda ok as query string value and variable name
 export default function getSubjectId(modulePath: string, namedExport: string): string {
-    const cwd = process.cwd();
-
-    return `${namedExport}_${getHashCode(path.relative(cwd, path.resolve(cwd, modulePath)))}`;
+    return `${namedExport}_${getHashCode(path.relative(CWD, path.resolve(CWD, modulePath)))}`;
 }

--- a/packages/perftool/package.json
+++ b/packages/perftool/package.json
@@ -56,7 +56,8 @@
         "morgan": "1.10.0",
         "puppeteer": "19.9.1",
         "ts-node": "10.9.1",
-        "webpack": "5.79.0"
+        "webpack": "5.79.0",
+        "typescript": "5.0.4"
     },
     "devDependencies": {
         "@jest/globals": "29.5.0",
@@ -70,8 +71,7 @@
         "jest-environment-jsdom": "29.5.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "ts-jest": "29.1.0",
-        "typescript": "5.0.4"
+        "ts-jest": "29.1.0"
     },
     "contributors": [
         "Artem Khaidarov (https://github.com/akhdrv)"

--- a/packages/perftool/scripts/start-compare.sh
+++ b/packages/perftool/scripts/start-compare.sh
@@ -15,12 +15,14 @@ case "$(uname -s)" in
   *)          SCRIPT_PATH="$(readlink -f "$0")";;
 esac
 
+CWD=$(pwd)
 PROJECT_DIR="$(dirname "$SCRIPT_PATH")/.."
-TS_NODE_ESM_PATH=$(cd "$PROJECT_DIR" && node -e "console.log(require.resolve('ts-node/esm'))")
+TS_NODE_ESM_PATH=$(cd "$PROJECT_DIR" && node -p "require.resolve('ts-node/esm')")
 OPTS="--loader $TS_NODE_ESM_PATH --experimental-specifier-resolution=node"
 
 if [ -z "$PERFTOOL_DEBUG" ]; then
   OPTS="$OPTS --no-warnings"
 fi
 
-NODE_OPTIONS=$OPTS TS_NODE_PROJECT="$PROJECT_DIR/tsconfig.json" TS_NODE_FILES=true node "$PROJECT_DIR/lib/compare/index.ts" "$@"
+cd "$PROJECT_DIR" && \
+ PERFTOOL_CWD=$CWD NODE_OPTIONS=$OPTS TS_NODE_FILES=true node lib/compare/index.ts "$@"

--- a/packages/perftool/scripts/start.sh
+++ b/packages/perftool/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -e
+set -ex
 
 case "$(uname -s)" in
   Darwin*)
@@ -15,12 +15,14 @@ case "$(uname -s)" in
   *)          SCRIPT_PATH="$(readlink -f "$0")";;
 esac
 
+CWD=$(pwd)
 PROJECT_DIR="$(dirname "$SCRIPT_PATH")/.."
-TS_NODE_ESM_PATH=$(cd "$PROJECT_DIR" && node -e "console.log(require.resolve('ts-node/esm'))")
+TS_NODE_ESM_PATH=$(cd "$PROJECT_DIR" && node -p "require.resolve('ts-node/esm')")
 OPTS="--loader $TS_NODE_ESM_PATH --experimental-specifier-resolution=node"
 
 if [ -z "$PERFTOOL_DEBUG" ]; then
   OPTS="$OPTS --no-warnings"
 fi
 
-NODE_OPTIONS=$OPTS TS_NODE_PROJECT="$PROJECT_DIR/tsconfig.json" TS_NODE_FILES=true node "$PROJECT_DIR/lib/index.ts" "$@"
+cd "$PROJECT_DIR" && \
+ PERFTOOL_CWD=$CWD NODE_OPTIONS=$OPTS TS_NODE_FILES=true node lib/index.ts "$@"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       eslint-plugin-jest:
         specifier: 27.2.1
         version: 27.2.1(@typescript-eslint/eslint-plugin@5.58.0)(eslint@8.38.0)(typescript@5.0.4)
+      eslint-plugin-jsx-a11y:
+        specifier: 6.7.1
+        version: 6.7.1(eslint@8.38.0)
       eslint-plugin-prettier:
         specifier: 4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.38.0)(prettier@2.8.7)
@@ -121,6 +124,9 @@ importers:
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@swc/core@1.3.50)(@types/node@18.15.11)(typescript@5.0.4)
+      typescript:
+        specifier: 5.0.4
+        version: 5.0.4
       webpack:
         specifier: 5.79.0
         version: 5.79.0(@swc/core@1.3.50)
@@ -161,9 +167,6 @@ importers:
       ts-jest:
         specifier: 29.1.0
         version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
-      typescript:
-        specifier: 5.0.4
-        version: 5.0.4
 
   spec/main-suite:
     dependencies:
@@ -7839,7 +7842,7 @@ packages:
       strong-log-transformer: 2.1.0
       tar: 6.1.11
       temp-dir: 1.0.0
-      typescript: 3.9.10
+      typescript: 4.0.8
       upath: 2.0.1
       uuid: 8.3.2
       validate-npm-package-license: 3.0.4
@@ -10983,8 +10986,8 @@ packages:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
     dev: true
 
-  /typescript@3.9.10:
-    resolution: {integrity: sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==}
+  /typescript@4.0.8:
+    resolution: {integrity: sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/spec/main-suite/start.sh
+++ b/spec/main-suite/start.sh
@@ -11,8 +11,17 @@ mv *.tgz ../../spec/main-suite/perftool.tgz
 
 cd "$REPO_ROOT/spec/main-suite"
 
+REACT_INSTALL_ARG=""
+REACT_DOM_INSTALL_ARG=""
+TYPESCRIPT_INSTALL_ARG=""
+
 if [ -n "$REACT_VERSION" ]; then
-  pnpm add ./perftool.tgz "react@$REACT_VERSION" "react-dom@$REACT_VERSION"
-else
-  pnpm add ./perftool.tgz
+  REACT_INSTALL_ARG="react@$REACT_VERSION"
+  REACT_DOM_INSTALL_ARG="react-dom@$REACT_VERSION"
 fi
+
+if [ -n "$TYPESCRIPT_VERSION" ]; then
+  TYPESCRIPT_INSTALL_ARG="typescript@$TYPESCRIPT_VERSION"
+fi
+
+pnpm add ./perftool.tgz "$REACT_INSTALL_ARG" "$REACT_DOM_INSTALL_ARG" "$TYPESCRIPT_INSTALL_ARG"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.9.0-canary.15.5050283029.0
  # or 
  yarn add @salutejs/perftool@0.9.0-canary.15.5050283029.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
