### PR TITLE
Early exit & no display bootstrap script content

### DIFF
--- a/packages/perftool/lib/index.ts
+++ b/packages/perftool/lib/index.ts
@@ -45,6 +45,12 @@ async function start() {
     const config = getConfig(cliConfig, importedConfig?.value);
 
     const testModules = await collectTestSubjects(config);
+
+    if (!testModules.length) {
+        info('No test modules found, exiting');
+        return;
+    }
+
     const tasks = getAllTasks(config);
 
     info(

--- a/packages/perftool/scripts/start-compare.sh
+++ b/packages/perftool/scripts/start-compare.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ -n "$PERFTOOL_DEBUG" ]; then
+  set -x
+fi
+
 case "$(uname -s)" in
   Darwin*)
     TRAVERSED_LINK=$(readlink $0 || true)

--- a/packages/perftool/scripts/start.sh
+++ b/packages/perftool/scripts/start.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
 
-set -ex
+set -e
+
+if [ -n "$PERFTOOL_DEBUG" ]; then
+  set -x
+fi
 
 case "$(uname -s)" in
   Darwin*)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.9.1-canary.18.5067761980.0
  # or 
  yarn add @salutejs/perftool@0.9.1-canary.18.5067761980.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
