### PR TITLE
fix(perftool): use wait factor only once

### DIFF
--- a/packages/perftool/lib/client/measurement/types.ts
+++ b/packages/perftool/lib/client/measurement/types.ts
@@ -8,6 +8,10 @@ export type MeasurerConfig = {
 
 export type TaskAim = 'increase' | 'decrease';
 
+export type State = {
+    cached?: boolean;
+};
+
 type RunParams<C extends MeasurerConfig | void, S extends object> = {
     /**
      * Component to test
@@ -30,7 +34,7 @@ type RunParams<C extends MeasurerConfig | void, S extends object> = {
 export type TaskState<T extends Task<any, any, any>> = T extends Task<any, any, infer S> ? S : never;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type Task<T extends JSONSerializable, C extends MeasurerConfig | void, S extends object = {}> = {
+export type Task<T extends JSONSerializable, C extends MeasurerConfig | void, S extends State = {}> = {
     /**
      * Internal id (for JSON reports)
      */

--- a/packages/perftool/lib/controller/executor.ts
+++ b/packages/perftool/lib/controller/executor.ts
@@ -41,8 +41,16 @@ export default class Executor<T extends Task<any, any, any>[]> implements IExecu
 
         if (!this.stateMap.has(key)) {
             const cachedState = this.cache.getTaskState(test.subjectId, test.taskId);
+            let state = {} as TaskState<T[number]>;
 
-            this.stateMap.set(key, (cachedState || {}) as TaskState<T[number]>);
+            if (cachedState) {
+                state = {
+                    ...(cachedState as TaskState<T[number]>),
+                    cached: true,
+                };
+            }
+
+            this.stateMap.set(key, state);
         }
 
         const state = this.stateMap.get(key)!;
@@ -57,8 +65,10 @@ export default class Executor<T extends Task<any, any, any>[]> implements IExecu
         const { taskId, subjectId, state } = result;
         const key = this.getStateKey(taskId, subjectId);
 
-        this.stateMap.set(key, state!);
-        this.cache.setTaskState(subjectId, taskId, state!);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { cached: _, ...filteredState } = state || ({} as TaskState<T[number]>);
+        this.stateMap.set(key, filteredState as TaskState<T[number]>);
+        this.cache.setTaskState(subjectId, taskId, filteredState);
         result.state = undefined;
     };
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.10.1-canary.20.5189745419.0
  # or 
  yarn add @salutejs/perftool@0.10.1-canary.20.5189745419.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
