### PR TITLE
Fix switch components in preview mode

### DIFF
--- a/packages/perftool/lib/api/intercept.ts
+++ b/packages/perftool/lib/api/intercept.ts
@@ -56,6 +56,10 @@ export async function useInterceptApi(page: Page): Promise<void> {
         }
     }
 
+    function resetRequestReplacement() {
+        requestReplacementByMethodMap.clear();
+    }
+
     async function setRequestReplacement({
         method = ANY_METHOD,
         response,
@@ -146,6 +150,7 @@ export async function useInterceptApi(page: Page): Promise<void> {
     }
 
     await page.exposeFunction('_perftool_intercept', setRequestReplacement);
+    await page.exposeFunction('_perftool_reset_interception', resetRequestReplacement);
     await page.setRequestInterception(true);
 
     page.on('request', handleInterceptedRequest);

--- a/packages/perftool/lib/controller/clientScript.ts
+++ b/packages/perftool/lib/controller/clientScript.ts
@@ -8,10 +8,7 @@ export function bootstrapTest(serializedTest: string) {
      * @see utils/window.d.ts
      */
     window._perftool_test = test;
-
-    if (window._perftool_api_ready) {
-        window._perftool_api_ready();
-    }
+    window._perftool_api_ready?.();
 }
 
 export function createInsertionScriptContent<T extends Task<any, any, any>>(test: RawTest<T>) {

--- a/packages/perftool/lib/preview/controller.ts
+++ b/packages/perftool/lib/preview/controller.ts
@@ -52,15 +52,18 @@ class PreviewController {
         const baseUrl = `http://localhost:${this.port}`;
 
         const page = await createNewPage(this.browserInstance);
-        await page.goto(baseUrl);
+
+        page.on('load', async () => {
+            await page.evaluate(() => {
+                window._perftool_preview_loaded = true;
+                window._perftool_api_ready?.();
+            });
+        });
 
         await useInterceptApi(page);
         await useViewportApi(page);
 
-        await page.evaluate(() => {
-            window._perftool_preview_loaded = true;
-            window._perftool_api_ready?.();
-        });
+        await page.goto(baseUrl);
 
         await this.waitForPageClose(page);
     }

--- a/packages/perftool/lib/preview/index.tsx
+++ b/packages/perftool/lib/preview/index.tsx
@@ -50,6 +50,7 @@ export async function createPreviewClient({ subjects }: Params): Promise<void> {
     };
 
     await waitForApiReady();
+    await window._perftool_reset_interception?.();
 
     if (typeof currentSubject.Component.beforeTest === 'function') {
         debug('Running beforeTest');

--- a/packages/perftool/lib/typings/window.d.ts
+++ b/packages/perftool/lib/typings/window.d.ts
@@ -14,6 +14,7 @@ declare global {
         _perftool_finish?: <T extends Task<any, any, any>[]>(result: RunTaskResult<T[number]>) => Promise<void>;
         /** Intercept API **/
         _perftool_intercept?: (params: InterceptParams) => Promise<void>;
+        _perftool_reset_interception?: () => Promise<void>;
         /** Viewport API **/
         _perftool_set_viewport?: (viewport: SetViewportParams) => Promise<void>;
         _perftool_preview_loaded?: true;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/perftool@0.16.1-canary.159.6090369732.0
  # or 
  yarn add @salutejs/perftool@0.16.1-canary.159.6090369732.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
